### PR TITLE
Removing "lastmod" tag from sitemap

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,7 +1,6 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 <url>
 <loc>https://alpha.ca.gov/</loc>
-<lastmod>2019-12-10T22:45:02+00:00</lastmod>
 <priority>1.00</priority>
 </url>
 </urlset>


### PR DESCRIPTION
We aren't going to attempt to automate the "lastmod" date at this time, so it would be best to leave it blank.