### PR TITLE
Update index.html

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -54,7 +54,7 @@
       </div>
       <div class="col-md-6">
         <div class="list-group one-column-fix">
-          <a href="services/state-of-california-employee-holidays" class="list-group-item list-group-item-action lead">Find California employee holidays</a>
+          <a href="services/state-of-california-employee-holidays" class="list-group-item list-group-item-action lead">State of California employee holidays</a>
 		  <a href="services/find-food-banks-near-you" class="list-group-item list-group-item-action lead">Find food banks near you</a>
         </div>
       </div>


### PR DESCRIPTION
-Changing link title from "Find California employee holidays" to "State of California employee holidays" to match the h1 of the page. (Plus "California employee" could mean anyone who works in California, not just State workers.)